### PR TITLE
Jwaldor/addtopsongs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,11 +73,9 @@ function App() {
         console.log("calling API");
         apiServices
           .getRecs(playerState.track_window.current_track.id)
-          .then((res) => {
-            console.log("body", res);
-            return res.body;
-          })
-          .then((res) => console.log(res.values()));
+          .then((res) => res.json())
+          .then((res) => setRecList(res.tracks.slice(0, 5)));
+        // .then((res) => console.log(res.values()));
       }
     }
   };
@@ -338,11 +336,19 @@ function App() {
               </div>
             </div>
             <ul className="menu max-h-sm pb-28 rounded-l-none rounded-br-none rounded-tr-lg bg-base-300 shadow-lg mt-3 bg-gradient-to-r from-base-300 to-transparent min-w-fit">
-              <li className="menu-title font-light">Top Songs</li>
-              <li className="font-light">
-                {/* <a>
-                    {topItems.map((item) => (
-                      <div>
+              <li className="menu-title font-light">
+                Recommendations based on current song
+              </li>
+
+              {recList.map((item) => (
+                <li className="font-light">
+                  <a>
+                    <div>
+                      <button
+                        onClick={() => {
+                          transferPlaybackSong(item.uri);
+                        }}
+                      >
                         <svg
                           className="w-6 h-6 text-gray-800 dark:text-white bg-green-800 rounded-full"
                           aria-hidden="false"
@@ -361,10 +367,12 @@ function App() {
                           />
                         </svg>{" "}
                         {item.name}
-                      </div>
-                    ))}
-                  </a> */}
-              </li>
+                      </button>
+                    </div>
+                  </a>
+                </li>
+              ))}
+
               {/* <li className="font-light">
                   <a>Purple Lamborghini</a>
                 </li>

--- a/src/api.ts
+++ b/src/api.ts
@@ -36,8 +36,8 @@ export const SpotifyServices = (access_token: string) => {
           Authorization: `Bearer ${access_token}`,
         },
       }),
-    getRecs: () =>
-      fetch(``, {
+    getRecs: (id: string) =>
+      fetch(`https://api.spotify.com/v1/recommendations?seed_tracks=${id}`, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",

--- a/src/api.ts
+++ b/src/api.ts
@@ -37,13 +37,28 @@ export const SpotifyServices = (access_token: string) => {
         },
       }),
     getRecs: () =>
-      fetch(`https://api.spotify.com/v1/me`, {
+      fetch(``, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${access_token}`,
         },
       }),
+    saveTrack: (id: string) =>
+      fetch(
+        `https://api.spotify.com/v1/me/tracks
+`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${access_token}`,
+          },
+          body: JSON.stringify({
+            ids: id,
+          }),
+        }
+      ),
   };
 };
 

--- a/src/components/PausePlay.tsx
+++ b/src/components/PausePlay.tsx
@@ -26,7 +26,6 @@ export default function PausePlay({
   //   aColor: "#FFF",
   //   curve: bezier(),
   // });
-  console.log("album_art", album_art);
 
   const controls = useAnimationControls();
 


### PR DESCRIPTION
can now view recommended songs
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fc00c617c4705f35ad0b95977bea11cd63884c34  | 
|--------|--------|

### Summary:
This PR adds functionality to display and play recommended songs based on the current track in the Spotify player app.

**Key points**:
- Added `playerState` state in `src/App.tsx` to track player state changes.
- Implemented `songSetup` and `refreshRecommendations` functions in `src/App.tsx` to update current song info and fetch recommendations.
- Updated `useEffect` hooks in `src/App.tsx` to handle player state changes and API service initialization.
- Modified `getRecs` function in `src/api.ts` to fetch recommendations based on current track ID.
- Updated UI in `src/App.tsx` to display recommended songs and handle playback using `transferPlaybackSong` function.
- Removed redundant `songSetup` function and console logs in `src/App.tsx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->